### PR TITLE
(update-metadata.ps1) Adding File & Dependency with tests

### DIFF
--- a/Wormies-AU-Helpers/public/Update-Metadata.ps1
+++ b/Wormies-AU-Helpers/public/Update-Metadata.ps1
@@ -7,6 +7,7 @@ Updates the metadata nuspec file with the specified information.
 .DESCRIPTION
 When a key and value is specified, update the metadata element with the specified key
 and the corresponding value in the specified NuspecFile.
+Singlular metadata elements are the only ones changed at this time.
 
 .PARAMETER key
 The element that should be updated in the metadata section.
@@ -29,8 +30,21 @@ Update-Metadata -data @{ title = 'My Awesome Title' }
 .EXAMPLE
 @{ title = 'My Awesome Title' } | Update-Metadata
 
+.EXAMPLE
+Update-Metadata -data @{ dependency = 'kb2919355,1.0.20160915' }
+
+.EXAMPLE
+@{ dependency = 'kb2919355,1.0.20160915' } | Update-Metadata
+
+.EXAMPLE
+Update-Metadata -data @{ file = 'tools\**,tools' }
+
+.EXAMPLE
+@{ file = 'tools\**,tools' } | Update-Metadata
+
 .NOTES
     Will throw an exception if the specified key doesn't exist in the nuspec file.
+    Will throw an exception if zero/more file/dependency key exist in the nuspec file.
 
     While the parameter `NuspecFile` accepts globbing patterns,
     it is expected to only match a single file.
@@ -57,11 +71,46 @@ function Update-Metadata {
     $nu.PSBase.PreserveWhitespace = $true
     $nu.Load($NuspecFile)
     $data.Keys | ForEach-Object {
-        if ($nu.package.metadata."$_") {
-            $nu.package.metadata."$_" = $data[$_]
-        }
-        else {
-            throw "$_ does not exist on the metadata element in the nuspec file"
+        switch -regex ($_) {
+            '^(file|files)$' {
+                $src, $target = $data[$_] -split (",")
+                if (($src -isnot [string]) -or ($target -isnot [string])) {
+                    Write-Verbose "$src or $target is not a valid string";
+                }
+                else {
+                    if ( ($nu.package.files.ChildNodes.Count) -eq 3 ) {
+                       $nu.package.files.file.src = $src
+                       $nu.package.files.file.target = $target
+                    }
+                    else {
+                       Write-Verbose "Zero or more than one Files Child Node found"
+                    }
+                }
+            }
+            '^(dependency|dependencies)$' {
+                $id, $version = $data[$_] -split (",")
+                if (($id -isnot [string]) -or ($version -isnot [string]))  {
+                    Write-Verbose "$id or $version is not a valid string";
+                }
+                else {
+                    if ( ($nu.package.metadata.dependencies.ChildNodes.Count) -eq 3 ) {
+                       $nu.package.metadata.dependencies.dependency.id = $id
+                       $nu.package.metadata.dependencies.dependency.version = $version
+                    }
+                    else {
+                       Write-Verbose "Zero or more than one dependencies Child Node found"
+                    }
+                }
+            }
+            default {
+                if ( $nu.package.metadata."$_" ) {
+                    $nu.package.metadata."$_" = $data[$_]
+                }
+                else {
+                    Write-Verbose "$_ does not exist on the metadata element in the nuspec file"
+                }
+            }
+            
         }
     }
 

--- a/Wormies-AU-Helpers/public/Update-Metadata.ps1
+++ b/Wormies-AU-Helpers/public/Update-Metadata.ps1
@@ -75,7 +75,7 @@ function Update-Metadata {
             '^(file|files)$' {
                 $src, $target = $data[$_] -split (",")
                 if (($src -isnot [string]) -or ($target -isnot [string])) {
-                    Write-Verbose "$src or $target is not a valid string";
+                    throw "$src or $target is not a valid string";
                 }
                 else {
                     if ( ($nu.package.files.ChildNodes.Count) -eq 3 ) {
@@ -83,14 +83,14 @@ function Update-Metadata {
                        $nu.package.files.file.target = $target
                     }
                     else {
-                       Write-Verbose "Zero or more than one Files Child Node found"
+                       throw "Zero or more than one Files Child Node found"
                     }
                 }
             }
             '^(dependency|dependencies)$' {
                 $id, $version = $data[$_] -split (",")
                 if (($id -isnot [string]) -or ($version -isnot [string]))  {
-                    Write-Verbose "$id or $version is not a valid string";
+                    throw "$id or $version is not a valid string";
                 }
                 else {
                     if ( ($nu.package.metadata.dependencies.ChildNodes.Count) -eq 3 ) {
@@ -98,7 +98,7 @@ function Update-Metadata {
                        $nu.package.metadata.dependencies.dependency.version = $version
                     }
                     else {
-                       Write-Verbose "Zero or more than one dependencies Child Node found"
+                       throw "Zero or more than one dependencies Child Node found"
                     }
                 }
             }
@@ -107,7 +107,7 @@ function Update-Metadata {
                     $nu.package.metadata."$_" = $data[$_]
                 }
                 else {
-                    Write-Verbose "$_ does not exist on the metadata element in the nuspec file"
+                    throw "$_ does not exist on the metadata element in the nuspec file"
                 }
             }
             


### PR DESCRIPTION
@AdmiringWorm 
This will add the ability to change Singular File & Dependency in nuspec package/metadata.
These are updated to be the same formatting as older files.
Update-Metadata function has been updated to use a switch instead of all the if and else statements which may increase the speed of the function