### PR TITLE
(update-metadata.ps1) Adding File & Dependency with tests

### DIFF
--- a/Wormies-AU-Helpers/public/Update-Metadata.ps1
+++ b/Wormies-AU-Helpers/public/Update-Metadata.ps1
@@ -1,4 +1,4 @@
-﻿$ErrorActionPreference = 'Stop'
+$ErrorActionPreference = 'Stop'
 
 <#
 .SYNOPSIS
@@ -7,6 +7,13 @@ Updates the metadata nuspec file with the specified information.
 .DESCRIPTION
 When a key and value is specified, update the metadata element with the specified key
 and the corresponding value in the specified NuspecFile.
+Updating a file/dependency key must have at least one attribute defined.
+( EX: <file src="" /> -or- <dependency id="" /> )
+The updating of file/dependency key uses a pipe delimiter instead of comma. 
+When updating file/dependency key that has multiple file/dependency key requires
+a change value. This value is counted from one. The value must follow the values of
+the attributes being changed. The Attributes for File are src, target, & exclude.
+The Attributes for Dependency are id, version, exclude, & include.
 
 .PARAMETER key
 The element that should be updated in the metadata section.
@@ -24,13 +31,42 @@ Update-Metadata -key releaseNotes -value "https://github.com/majkinetor/AU/relea
 Update-Metadata -key releaseNotes -value "https://github.com/majkinetor/AU/releases/latest" -NuspecFile ".\package.nuspec"
 
 .EXAMPLE
+This is an example of changing the Title of the nuspec file
 Update-Metadata -data @{ title = 'My Awesome Title' }
-
-.EXAMPLE
+- or -
 @{ title = 'My Awesome Title' } | Update-Metadata
 
+.EXAMPLE
+This is an example of changing the id and version attributes for the dependency key
+Update-Metadata -data @{ dependency = 'kb2919355|1.0.20160915' }
+- or -
+@{ dependency = 'kb2919355|1.0.20160915' } | Update-Metadata
+
+.EXAMPLE
+This is an example of changing the id and include attributes at the second dependency key
+Without changing the values for attributes version or exclude (if present)
+Update-Metadata -data @{ dependency = 'kb2919355||1.0.20160915,2' }
+- or -
+@{ dependency = 'kb2919355||1.0.20160915,2' } | Update-Metadata
+
+.EXAMPLE
+This is an example of changing the src and target attributes for the file key
+Update-Metadata -data @{ file = 'tools\**|tools' }
+- or -
+@{ file = 'tools\**|tools' } | Update-Metadata
+
+.EXAMPLE
+This is an example of changing the src and exclude attributes at the second file key
+Without changing the values for attribute target
+Update-Metadata -data @{ file = 'tools\**||tools,2' }
+- or -
+@{ file = 'tools\**||tools,2' } | Update-Metadata
+
 .NOTES
-    Will throw an exception if the specified key doesn't exist in the nuspec file.
+    Will now show a warning if the specified key doesn't exist in the nuspec file.
+    Will now show a warning when the change value for file/dependency key is greater than currently in the nuspec file.
+    Will now show a warning when file/dependency key doesn't have any defined attributes.
+    Will now show a warning when the change value has been omitted due to nodes not allowing change at that key.
 
     While the parameter `NuspecFile` accepts globbing patterns,
     it is expected to only match a single file.
@@ -45,7 +81,7 @@ function Update-Metadata {
         [Parameter(Mandatory = $true, ParameterSetName = "Single")]
         [string]$value,
         [Parameter(Mandatory = $true, ParameterSetName = "Multiple", ValueFromPipeline = $true)]
-        [hashtable]$data = @{$key = $value},
+        [hashtable]$data = [ordered] @{$key = $value},
         [ValidateScript( { Test-Path $_ })]
         [SupportsWildcards()]
         [string]$NuspecFile = ".\*.nuspec"
@@ -57,12 +93,50 @@ function Update-Metadata {
     $nu.PSBase.PreserveWhitespace = $true
     $nu.Load($NuspecFile)
     $data.Keys | ForEach-Object {
-        if ($nu.package.metadata."$_") {
-            $nu.package.metadata."$_" = $data[$_]
+        switch -Regex ($_) {
+            '^(file)$' {
+                $metaData = "files"; $NodeGroup = $nu.package.$metaData
+                $NodeData,[int]$change = $data[$_] -split (",")
+                $NodeCount = $nu.package.$metaData.ChildNodes.Count; $src,$target,$exclude = $NodeData -split ("\|")
+                $NodeAttributes = [ordered] @{"src" = $src;"target" = $target;"exclude" = $exclude}
+                $change = @{$true="0";$false=($change - 1)}[ ([string]::IsNullOrEmpty($change)) ]
+                if ($NodeCount -eq 3) { $NodeGroup = $NodeGroup."$_"; $omitted = $true } else { $NodeGroup = $NodeGroup.$_[$change] }
+            }
+            '^(dependency)$' {
+                $MetaNode = $_ -replace("y","ies"); $metaData = "metadata"
+                $NodeData,[int]$change = $data[$_] -split (",")
+                $NodeGroup = $nu.package.$metaData.$MetaNode; $NodeCount = $nu.package.$metaData.$MetaNode.ChildNodes.Count
+                $id,$version,$include,$exclude = $NodeData -split ("\|")
+                $NodeAttributes = [ordered] @{"id" = $id;"version" = $version;"include" = $include;"exclude" = $exclude}
+                $change = @{$true="0";$false=($change - 1)}[ ([string]::IsNullOrEmpty($change)) ]
+                if ($NodeCount -eq 3) { $NodeGroup = $NodeGroup."$_"; $omitted = $true } else { $NodeGroup = $NodeGroup.$_[$change] }
+            }
+            default {
+                if ( $nu.package.metadata."$_" ) {
+                    $nu.package.metadata."$_" = $data[$_]
+                }
+                else {
+                    Write-Warning "$_ does not exist on the metadata element in the nuspec file"
+                }
+            }
         }
-        else {
-            throw "$_ does not exist on the metadata element in the nuspec file"
-        }
+        if ($_ -match '^(dependency)$|^(file)$') {
+            if (($change -gt $NodeCount)) {
+                Write-Warning "$change is greater than $NodeCount of $_ Nodes"
+            }
+            if ($omitted) {
+                Write-Warning "Change has been omitted due to $_ not having that number of Nodes"
+            }
+            foreach ( $attrib in $NodeAttributes.keys ) {
+                if (!([string]::IsNullOrEmpty($NodeAttributes[$attrib])) ) {
+                    if (![string]::IsNullOrEmpty( $NodeGroup.Attributes ) ) {
+                        $NodeGroup.SetAttribute($attrib, $NodeAttributes[$attrib] )
+                    } else { 
+                        Write-Warning "Attribute $attrib not defined for $_ in the nuspec file"
+                    }
+                }
+            }
+        } 
     }
 
     $utf8NoBom = New-Object System.Text.UTF8Encoding($false)

--- a/Wormies-AU-Helpers/public/Update-Metadata.ps1
+++ b/Wormies-AU-Helpers/public/Update-Metadata.ps1
@@ -7,13 +7,7 @@ Updates the metadata nuspec file with the specified information.
 .DESCRIPTION
 When a key and value is specified, update the metadata element with the specified key
 and the corresponding value in the specified NuspecFile.
-Updating a file/dependency key must have at least one attribute defined.
-( EX: <file src="" /> -or- <dependency id="" /> )
-The updating of file/dependency key uses a pipe delimiter instead of comma. 
-When updating file/dependency key that has multiple file/dependency key requires
-a change value. This value is counted from one. The value must follow the values of
-the attributes being changed. The Attributes for File are src, target, & exclude.
-The Attributes for Dependency are id, version, exclude, & include.
+Singlular metadata elements are the only ones changed at this time.
 
 .PARAMETER key
 The element that should be updated in the metadata section.
@@ -43,30 +37,21 @@ Update-Metadata -data @{ dependency = 'kb2919355|1.0.20160915' }
 @{ dependency = 'kb2919355|1.0.20160915' } | Update-Metadata
 
 .EXAMPLE
-This is an example of changing the id and include attributes at the second dependency key
-Without changing the values for attributes version or exclude (if present)
-Update-Metadata -data @{ dependency = 'kb2919355||1.0.20160915,2' }
-- or -
-@{ dependency = 'kb2919355||1.0.20160915,2' } | Update-Metadata
-
-.EXAMPLE
-This is an example of changing the src and target attributes for the file key
-Update-Metadata -data @{ file = 'tools\**|tools' }
+This is an example of changing the src and target attributes
+Update-Metadata -data @{ file = 'tools\**,tools' }
 - or -
 @{ file = 'tools\**|tools' } | Update-Metadata
 
 .EXAMPLE
-This is an example of changing the src and exclude attributes at the second file key
-Without changing the values for attribute target
-Update-Metadata -data @{ file = 'tools\**||tools,2' }
-- or -
-@{ file = 'tools\**||tools,2' } | Update-Metadata
+This is an example of changing the file src and target attributes for the first file element in the nuspec file.
+If only one file element is found the change value is omitted.
+@{ file = 'tools\**|tools,1' } | Update-Metadata
 
 .NOTES
     Will now show a warning if the specified key doesn't exist in the nuspec file.
-    Will now show a warning when the change value for file/dependency key is greater than currently in the nuspec file.
-    Will now show a warning when file/dependency key doesn't have any defined attributes.
-    Will now show a warning when the change value has been omitted due to nodes not allowing change at that key.
+    Will now show a warning when change for file/dependency key is greater than currently in the nuspec file.
+    Will now show a warning when change has been omitted due to nodes not allowing change at that key.
+    Will now show a warning when file/dependency doesn't have any attributes defined to be updated.
 
     While the parameter `NuspecFile` accepts globbing patterns,
     it is expected to only match a single file.
@@ -81,10 +66,11 @@ function Update-Metadata {
         [Parameter(Mandatory = $true, ParameterSetName = "Single")]
         [string]$value,
         [Parameter(Mandatory = $true, ParameterSetName = "Multiple", ValueFromPipeline = $true)]
-        [hashtable]$data = [ordered] @{$key = $value},
+        [hashtable]$data = @{$key = $value},
         [ValidateScript( { Test-Path $_ })]
         [SupportsWildcards()]
         [string]$NuspecFile = ".\*.nuspec"
+
     )
 
     $NuspecFile = Resolve-Path $NuspecFile
@@ -92,24 +78,46 @@ function Update-Metadata {
     $nu = New-Object xml
     $nu.PSBase.PreserveWhitespace = $true
     $nu.Load($NuspecFile)
+    $omitted = $true
     $data.Keys | ForEach-Object {
         switch -Regex ($_) {
             '^(file)$' {
-                $metaData = "files"; $NodeGroup = $nu.package.$metaData
+                $metaData = "files"
+                $NodeGroup = $nu.package.$metaData
                 $NodeData,[int]$change = $data[$_] -split (",")
-                $NodeCount = $nu.package.$metaData.ChildNodes.Count; $src,$target,$exclude = $NodeData -split ("\|")
-                $NodeAttributes = [ordered] @{"src" = $src;"target" = $target;"exclude" = $exclude}
+                $NodeCount = $nu.package.$metaData.ChildNodes.Count
+                $src,$target,$exclude = $NodeData -split ("\|")
+                $NodeAttributes = [ordered] @{
+                                              "src"     = $src
+                                              "target"  = $target
+                                              "exclude" = $exclude
+                                            }
                 $change = @{$true="0";$false=($change - 1)}[ ([string]::IsNullOrEmpty($change)) ]
-                if ($NodeCount -eq 3) { $NodeGroup = $NodeGroup."$_"; $omitted = $true } else { $NodeGroup = $NodeGroup.$_[$change] }
+                if ($NodeCount -eq 3) {
+                    $NodeGroup = $NodeGroup."$_"
+                } else {
+                    $NodeGroup = $NodeGroup.$_[$change]
+                }
             }
             '^(dependency)$' {
-                $MetaNode = $_ -replace("y","ies"); $metaData = "metadata"
+                $MetaNode = $_ -replace("y","ies")
+                $metaData = "metadata"
                 $NodeData,[int]$change = $data[$_] -split (",")
-                $NodeGroup = $nu.package.$metaData.$MetaNode; $NodeCount = $nu.package.$metaData.$MetaNode.ChildNodes.Count
+                $NodeGroup = $nu.package.$metaData.$MetaNode
+                $NodeCount = $nu.package.$metaData.$MetaNode.ChildNodes.Count
                 $id,$version,$include,$exclude = $NodeData -split ("\|")
-                $NodeAttributes = [ordered] @{"id" = $id;"version" = $version;"include" = $include;"exclude" = $exclude}
+                $NodeAttributes = [ordered] @{
+                                             "id"      = $id
+                                             "version" = $version
+                                             "include" = $include
+                                             "exclude" = $exclude
+                                            }
                 $change = @{$true="0";$false=($change - 1)}[ ([string]::IsNullOrEmpty($change)) ]
-                if ($NodeCount -eq 3) { $NodeGroup = $NodeGroup."$_"; $omitted = $true } else { $NodeGroup = $NodeGroup.$_[$change] }
+                if ($NodeCount -eq 3) {
+                    $NodeGroup = $NodeGroup."$_"
+                } else {
+                    $NodeGroup = $NodeGroup.$_[$change]
+                }
             }
             default {
                 if ( $nu.package.metadata."$_" ) {

--- a/tests/public/Update-Metadata.Tests.ps1
+++ b/tests/public/Update-Metadata.Tests.ps1
@@ -89,13 +89,13 @@ Describe "Update-Metadata" {
     }
 
     It "Can update dependency with id of 'WindowsNewKB' and the version of '0.20.8.1" {
-        ( Update-Metadata -key "dependency" -value "WindowsNewKB|0.20.8.1" -NuspecFile $nuspecFile 3>&1 ) -match "Change has been omitted due to dependency Nodes not having -1 Nodes" | Should Be $true
+        ( Update-Metadata -key "dependency" -value "WindowsNewKB|0.20.8.1" -NuspecFile $nuspecFile 3>&1 ) -match "Change has been omitted due to dependency not having that number of Nodes" | Should Be $true
 
         $nuspecFile | Should -FileContentMatchExactly "\<dependency id=`"WindowsNewKB`" version=`"0.20.8.1`" \/\>"
     }
 
     It "Can update file with src of 'tools\**' and the target of 'tools" {
-        ( Update-Metadata -key "file" -value "tools\**|tools" -NuspecFile $nuspecFile 3>&1 ) -match "Change has been omitted due to file Nodes not having -1 Nodes" | Should Be $true
+        ( Update-Metadata -key "file" -value "tools\**|tools" -NuspecFile $nuspecFile 3>&1 ) -match "Change has been omitted due to file not having that number of Nodes" | Should Be $true
 
         $nuspecFile | Should -FileContentMatchExactly "\<file src=`"tools\\\*\*`" target=`"tools`" \/\>"
     }
@@ -121,15 +121,15 @@ Describe "Update-Metadata" {
 
     Context 'Test Group of passing change number clearly outside of the number of file/dependency nodes' {
         It "Shows Warning when dependency 2 is not present in the nuspec file" {
-            ( Update-Metadata -data @{ dependency = 'kb2020813|0.20.8.13,2' } -NuspecFile $nuspecFile 3>&1 ) -match "Change has been omitted due to dependency Nodes not having 1 Nodes" | Should Be $true
+            ( Update-Metadata -data @{ dependency = 'kb2020813|0.20.8.13,2' } -NuspecFile $nuspecFile 3>&1 ) -match "Change has been omitted due to dependency not having that number of Nodes" | Should Be $true
             $nuspecFile | Should -FileContentMatchExactly "\<dependency id=`"kb2020813`" version=`"|0.20.8.13`" \/\>"
         }
         It "Shows Warning when file 87 is not present in the nuspec file" {
-            ( Update-Metadata -data @{ file = 'tools\**|content\any\any,87' }  -NuspecFile $nuspecFile 3>&1 ) -match "86 is greater than 3 of file Nodes" -and "Change has been omitted due to file Nodes not having 86 Nodes" | Should Be $true
+            ( Update-Metadata -data @{ file = 'tools\**|content\any\any,87' }  -NuspecFile $nuspecFile 3>&1 ) -match "86 is greater than 3 of file Nodes" -and "Change has been omitted due to file not having that number of Nodes" | Should Be $true
             $nuspecFile | Should -FileContentMatchExactly "\<file src=`"tools\\\*\*`" target=`"content\\any\\any`" \/\>"
         }
         It "Shows Warning when dependency 10 is not present in the nuspec file" {
-            ( Update-Metadata -data @{ dependency = 'kb2020812|0.20.8.12,10' } -NuspecFile $nuspecFile 3>&1 ) -match "9 is greater than 3 of dependency Nodes" -and "Change has been omitted due to dependency Nodes not having -1 Nodes" | Should Be $true
+            ( Update-Metadata -data @{ dependency = 'kb2020812|0.20.8.12,10' } -NuspecFile $nuspecFile 3>&1 ) -match "9 is greater than 3 of dependency Nodes" -and "Change has been omitted due to dependency not having that number of Nodes" | Should Be $true
             $nuspecFile | Should -FileContentMatchExactly "\<dependency id=`"kb2020812`" version=`"0.20.8.12`" \/\>"
         }
     }

--- a/tests/public/Update-Metadata.Tests.ps1
+++ b/tests/public/Update-Metadata.Tests.ps1
@@ -42,14 +42,14 @@ function Get-FileEncoding {
     }
 }
 
-Describe "Update-Metadata" {
+Describe "Update-Metadata Test With Attributes" {
     $nuspecFile = "$PSScriptRoot\test.nuspec"
     BeforeEach {
         $xml = @'
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Do not remove this test for UTF-8: if “Ω” doesn’t appear as greek uppercase omega letter enclosed in quotation marks, you should use an editor that supports UTF-8, not this one. -->
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
-    <metadata>
+  <metadata>
         <id>ValidNuspec</id>
         <title>Valid Test Nuspec</title>
         <version>1.0.3</version>
@@ -119,18 +119,158 @@ Describe "Update-Metadata" {
         Get-FileEncoding -Path $nuspecFile -DefaultEncoding $expectedEncoding | Should Be $expectedEncoding
     }
 
-    Context 'Test Group of passing change number clearly outside of the number of file/dependency nodes' {
-        It "Shows Warning when dependency 2 is not present in the nuspec file" {
-            ( Update-Metadata -data @{ dependency = 'kb2020813|0.20.8.13,2' } -NuspecFile $nuspecFile 3>&1 ) -match "Change has been omitted due to dependency not having that number of Nodes" | Should Be $true
-            $nuspecFile | Should -FileContentMatchExactly "\<dependency id=`"kb2020813`" version=`"|0.20.8.13`" \/\>"
-        }
-        It "Shows Warning when file 87 is not present in the nuspec file" {
-            ( Update-Metadata -data @{ file = 'tools\**|content\any\any,87' }  -NuspecFile $nuspecFile 3>&1 ) -match "86 is greater than 3 of file Nodes" -and "Change has been omitted due to file not having that number of Nodes" | Should Be $true
-            $nuspecFile | Should -FileContentMatchExactly "\<file src=`"tools\\\*\*`" target=`"content\\any\\any`" \/\>"
-        }
-        It "Shows Warning when dependency 10 is not present in the nuspec file" {
-            ( Update-Metadata -data @{ dependency = 'kb2020812|0.20.8.12,10' } -NuspecFile $nuspecFile 3>&1 ) -match "9 is greater than 3 of dependency Nodes" -and "Change has been omitted due to dependency not having that number of Nodes" | Should Be $true
-            $nuspecFile | Should -FileContentMatchExactly "\<dependency id=`"kb2020812`" version=`"0.20.8.12`" \/\>"
-        }
+    It "Shows Warning when dependency 2 is not present in the nuspec file" {
+        ( Update-Metadata -data @{ dependency = 'kb2020813|0.20.8.13,2' } -NuspecFile $nuspecFile 3>&1 ) -match "Change has been omitted due to dependency not having that number of Nodes" | Should Be $true
+        $nuspecFile | Should -FileContentMatchExactly "\<dependency id=`"kb2020813`" version=`"|0.20.8.13`" \/\>"
     }
+    It "Shows Warning when file 87 is not present in the nuspec file" {
+        ( Update-Metadata -data @{ file = 'tools\**|content\any\any,87' }  -NuspecFile $nuspecFile 3>&1 ) -match "86 is greater than 3 of file Nodes" -and "Change has been omitted due to file not having that number of Nodes" | Should Be $true
+        $nuspecFile | Should -FileContentMatchExactly "\<file src=`"tools\\\*\*`" target=`"content\\any\\any`" \/\>"
+    }
+    It "Shows Warning when dependency 10 is not present in the nuspec file" {
+        ( Update-Metadata -data @{ dependency = 'kb2020812|0.20.8.12,10' } -NuspecFile $nuspecFile 3>&1 ) -match "9 is greater than 3 of dependency Nodes" -and "Change has been omitted due to dependency not having that number of Nodes" | Should Be $true
+        $nuspecFile | Should -FileContentMatchExactly "\<dependency id=`"kb2020812`" version=`"0.20.8.12`" \/\>"
+    }
+}
+
+Describe "Update-Metadata Test Multiple File/Dependency Keys" {
+    $nuspecFile = "$PSScriptRoot\test.nuspec"
+    BeforeEach {
+        $xml = @'
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Do not remove this test for UTF-8: if “Ω” doesn’t appear as greek uppercase omega letter enclosed in quotation marks, you should use an editor that supports UTF-8, not this one. -->
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+  <metadata>
+        <id>ValidNuspec</id>
+        <title>Valid Test Nuspec</title>
+        <version>1.0.3</version>
+        <dependencies>
+          <dependency id="identity" />
+          <dependency exclude="exclude" />
+        </dependencies>
+  </metadata>
+  <files>
+    <file target="target" />
+    <file src="source" />
+  </files>
+</package>
+'@
+        $utf8NoBomEncoding = New-Object System.Text.UTF8Encoding($false)
+        [System.IO.File]::WriteAllText($nuspecFile, $xml, $utf8NoBomEncoding)
+    }
+
+    AfterEach {
+        Remove-Item $nuspecFile -Force
+    }
+
+    It "Testing for reading file attributes" {
+        $nuspecFile | Should -FileContentMatchExactly "\<file src=`"source`" \/\>"
+        $nuspecFile | Should -FileContentMatchExactly "\<file target=`"target`" \/\>"
+    }
+
+    It "Testing for changing only src attribute of second file key" {
+        Update-Metadata -data @{ file = 'new source,2' } -NuspecFile $nuspecFile
+        $nuspecFile | Should -FileContentMatchExactly "\<file src=`"new source`" \/\>"
+    }
+
+    It "Testing for changing only target attribute of first file key" {
+        Update-Metadata -data @{ file = '|new target,1' } -NuspecFile $nuspecFile
+        $nuspecFile | Should -FileContentMatchExactly "\<file target=`"new target`" \/\>"
+    }
+
+    It "Testing for changing only src attribute of second file key target attribute of first file key" {
+        Update-Metadata -data @{ file = 'third_source,2' } -NuspecFile $nuspecFile
+        $nuspecFile | Should -FileContentMatchExactly "\<file src=`"third_source`" \/\>"
+        Update-Metadata -data @{ file = '|third target,1' } -NuspecFile $nuspecFile
+        $nuspecFile | Should -FileContentMatchExactly "\<file target=`"third target`" \/\>"
+    }
+
+    It "Testing for changing only exclude attribute of second dependency key" {
+        Update-Metadata -data @{ dependency = '|||second exclude,2' } -NuspecFile $nuspecFile 
+        $nuspecFile | Should -FileContentMatchExactly "\<dependency exclude=`"second exclude`" \/\>"
+    }
+
+    It "Testing for changing only id attribute of first dependency key" {
+        Update-Metadata -data @{ dependency = 'first identity,1' } -NuspecFile $nuspecFile 
+        $nuspecFile | Should -FileContentMatchExactly "\<dependency id=`"first identity`" \/\>"
+    }
+
+    It "Testing for changing only exclude attribute of second dependency key id attribute of first dependency key" {
+        Update-Metadata -data @{ dependency = 'third_identity,1' } -NuspecFile $nuspecFile
+        $nuspecFile | Should -FileContentMatchExactly "\<dependency id=`"third_identity`" \/\>"
+        Update-Metadata -data @{ dependency = '|||third exclude,2' } -NuspecFile $nuspecFile
+        $nuspecFile | Should -FileContentMatchExactly "\<dependency exclude=`"third exclude`" \/\>"
+    }
+
+    It "Testing for changing only exclude attribute of second dependency and target attribute of first file key" {
+        Update-Metadata -data @{ dependency = '|||second exclude,2' } -NuspecFile $nuspecFile 
+        $nuspecFile | Should -FileContentMatchExactly "\<dependency exclude=`"second exclude`" \/\>"
+        Update-Metadata -data @{ file = '|new target,1' } -NuspecFile $nuspecFile
+        $nuspecFile | Should -FileContentMatchExactly "\<file target=`"new target`" \/\>"
+    }
+
+    It "Testing for changing all attributes of second dependency and first file key" {
+        Update-Metadata -data @{ dependency = 'ident|versions|includes|second exclude,2' } -NuspecFile $nuspecFile 
+        $nuspecFile | Should -FileContentMatchExactly "\<dependency exclude=`"second exclude`" id=`"ident`" version=`"versions`" include=`"includes`" \/\>"
+        Update-Metadata -data @{ file = 'sources|new target|excludes,1' } -NuspecFile $nuspecFile
+        $nuspecFile | Should -FileContentMatchExactly "\<file target=`"new target`" src=`"sources`" exclude=`"excludes`" \/\>"
+    }
+
+    It "Testing for changing all attributes except exclude of second dependency and target of first file key" {
+        Update-Metadata -data @{ dependency = 'ident|versions|includes,2' } -NuspecFile $nuspecFile 
+        $nuspecFile | Should -FileContentMatchExactly "\<dependency exclude=`"exclude`" id=`"ident`" version=`"versions`" include=`"includes`" \/\>"
+        Update-Metadata -data @{ file = 'sources||excludes,1' } -NuspecFile $nuspecFile
+        $nuspecFile | Should -FileContentMatchExactly "\<file target=`"target`" src=`"sources`" exclude=`"excludes`" \/\>"
+    }
+
+}
+
+Describe "Update-Metadata Test No Attributes Defined in File/Dependency Keys" {
+    $nuspecFile = "$PSScriptRoot\test.nuspec"
+    BeforeEach {
+        $xml = @'
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Do not remove this test for UTF-8: if “Ω” doesn’t appear as greek uppercase omega letter enclosed in quotation marks, you should use an editor that supports UTF-8, not this one. -->
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+  <metadata>
+        <id>ValidNuspec</id>
+        <title>Valid Test Nuspec</title>
+        <version>1.0.3</version>
+        <dependencies>
+          <dependency />
+        </dependencies>
+  </metadata>
+  <files>
+    <file />
+  </files>
+</package>
+'@
+        $utf8NoBomEncoding = New-Object System.Text.UTF8Encoding($false)
+        [System.IO.File]::WriteAllText($nuspecFile, $xml, $utf8NoBomEncoding)
+    }
+
+    AfterEach {
+        Remove-Item $nuspecFile -Force
+    }
+
+    It "Testing for updating file when no attributes defined and a change of 87" {
+        ( Update-Metadata -data @{ file = 'tools\**,87' } -NuspecFile $nuspecFile 3>&1 ) -match "Attribute src not defined for file in the nuspec file" -and "Change has been omitted due to file not having that number of Nodes" | Should Be $true
+        $nuspecFile | Should -FileContentMatchExactly "\<file \/\>"
+    }
+
+    It "Testing for updating dependency when no attributes defined and a change of 10" {
+        ( Update-Metadata -data @{ dependency = 'kb2020812,10' } -NuspecFile $nuspecFile 3>&1 ) -match "Attribute id not defined for dependency in the nuspec file" -and "Change has been omitted due to dependency not having that number of Nodes" | Should Be $true
+        $nuspecFile | Should -FileContentMatchExactly "\<dependency \/\>"
+    }
+
+    It "Testing for updating file when no attributes defined without change stated" {
+        ( Update-Metadata -data @{ file = 'tools\**' } -NuspecFile $nuspecFile 3>&1 ) -match "Attribute src not defined for file in the nuspec file" | Should Be $true
+        $nuspecFile | Should -FileContentMatchExactly "\<file \/\>"
+    }
+
+    It "Testing for updating dependency when no attributes defined without change stated" {
+        ( Update-Metadata -data @{ dependency = 'kb2020812' } -NuspecFile $nuspecFile 3>&1 ) -match "Attribute id not defined for dependency in the nuspec file"  | Should Be $true
+        $nuspecFile | Should -FileContentMatchExactly "\<dependency \/\>"
+    }
+
 }


### PR DESCRIPTION
@AdmiringWorm 
This is the newest update to the metadata function. This will do file/dependency and multiples of file/dependency if found in the nuspec file. 
It will not currently

- Add New Key/Element to the nuspec

- Update a file/dependency key that doesn't have any attribute defined `<file />` or `<dependency />`

Throws have been redone as warnings mainly to **_not stop_** the entire line from completing
`@{ id = "My Custom S iD";  dependency = 'kb2919355,1.0.20190915'; title = "My Custom X Title"; docs "http://SomeURI/folder/folder1/documentation" } | Update-Metadata`
